### PR TITLE
Arreglado error al reiniciar el juego desde game-finished

### DIFF
--- a/webapp/src/pages/Game.js
+++ b/webapp/src/pages/Game.js
@@ -188,7 +188,7 @@ function Game() {
           let maxScore = TOTAL_ROUNDS * BASE_SCORE * MULTIPLIER_HIGH;
           try {
             createUserHistory(score, totalTime, round, gameMode);
-            navigate('/game-finished', { state: { score: score, totalTime: totalTime, maxScore: maxScore } });
+            navigate('/game-finished', { state: { score: score, totalTime: totalTime, maxScore: maxScore, gameType: "normal" } });
           } catch (error) {
             console.error(error);
           }
@@ -282,7 +282,7 @@ function Game() {
           let maxScore = TOTAL_ROUNDS * BASE_SCORE * MULTIPLIER_HIGH;
           try {
             createUserHistory(thisScore, totalTime, correct, gameMode);
-            navigate('/game-finished', { state: { score: thisScore, totalTime: totalTime, maxScore: maxScore } });
+            navigate('/game-finished', { state: { score: thisScore, totalTime: totalTime, maxScore: maxScore, gameType: "normal" } });
           } catch (error) {
             console.error(error);
           }


### PR DESCRIPTION
Si se acababa una partida en Game y se volvía a jugar desde el botón de game-finished, no salía ninguna temática para las preguntas.